### PR TITLE
Optimize memory initialization

### DIFF
--- a/src/GPS.cpp
+++ b/src/GPS.cpp
@@ -4,22 +4,15 @@ void GPS::Run()
 {
 	logger = util::Logger(cfg.LOGFILE_ENABLED);
 
-	for (short i = 0; i < 1024; i++)
-	{
-		pathNodesToStream[i] = 1;
-	}
+        std::fill(std::begin(pathNodesToStream), std::end(pathNodesToStream), 1);
+        std::fill(std::begin(pathNodes), std::end(pathNodes), -1);
 
-	for (unsigned short i = 0; i < 50000; i++)
-	{
-		pathNodes[i] = -1;
-	}
-
-	plugin::patch::SetPointer(0x44DE3C, &pathNodesToStream);
-	plugin::patch::SetPointer(0x450D03, &pathNodesToStream);
-	plugin::patch::SetPointer(0x451782, &pathNodes);
-	plugin::patch::SetPointer(0x451904, &pathNodes);
-	plugin::patch::SetPointer(0x451AC3, &pathNodes);
-	plugin::patch::SetPointer(0x451B33, &pathNodes);
+        plugin::patch::SetPointer(0x44DE3C, pathNodesToStream.data());
+        plugin::patch::SetPointer(0x450D03, pathNodesToStream.data());
+        plugin::patch::SetPointer(0x451782, pathNodes.data());
+        plugin::patch::SetPointer(0x451904, pathNodes.data());
+        plugin::patch::SetPointer(0x451AC3, pathNodes.data());
+        plugin::patch::SetPointer(0x451B33, pathNodes.data());
 	plugin::patch::SetUInt(0x4518F8, 50000);
 	plugin::patch::SetUInt(0x4519B0, 49950);
 
@@ -56,7 +49,7 @@ constexpr void GPS::DrawRadarOverlayHandle()
 		return;
 
 	if (renderTargetRoute)
-		this->renderPath(targetTracePos, -1, false, targetNodesCount, t_ResultNodes, targetDistance, t_LineVerts);
+                this->renderPath(targetTracePos, -1, false, targetNodesCount, t_ResultNodes.data(), targetDistance, t_LineVerts.data());
 
 	if (renderMissionRoute)
 	{
@@ -118,7 +111,7 @@ void GPS::GameEventHandle()
 		CRadar::ms_RadarTrace[LOWORD(FrontEndMenuManager.m_nTargetBlipIndex)].m_nBlipDisplay)
 	{
 		targetTracePos = CRadar::ms_RadarTrace[LOWORD(FrontEndMenuManager.m_nTargetBlipIndex)].m_vecPos;
-		this->calculatePath(targetTracePos, targetNodesCount, t_ResultNodes, targetDistance);
+                this->calculatePath(targetTracePos, targetNodesCount, t_ResultNodes.data(), targetDistance);
 		renderTargetRoute = true;
 	}
 
@@ -390,9 +383,9 @@ constexpr void GPS::renderMissionTrace(tRadarTrace *trace)
 	// std::to_string(destVec.y));
 	if (renderMissionRoute)
 	{
-		this->calculatePath(destVec, missionNodesCount, m_ResultNodes, missionDistance);
+                this->calculatePath(destVec, missionNodesCount, m_ResultNodes.data(), missionDistance);
 
-		this->renderPath(destVec, trace->m_nColour, trace->m_bFriendly, missionNodesCount, m_ResultNodes,
-						 missionDistance, m_LineVerts);
+                this->renderPath(destVec, trace->m_nColour, trace->m_bFriendly, missionNodesCount, m_ResultNodes.data(),
+                                                 missionDistance, m_LineVerts.data());
 	}
 }

--- a/src/GPS.h
+++ b/src/GPS.h
@@ -16,6 +16,7 @@
 #include <limits>
 #include <future>
 #include <algorithm>
+#include <array>
 
 #include "CFont.h"
 #include "CGeneral.h"
@@ -89,14 +90,14 @@ private:
 	CVector2D tmpPoint;
 	CVector2D dir;
 	CVector nodePosn;
-	CVector2D shift[2];
-	char pathNodesToStream[1024];
-	int pathNodes[50000];
-	CVector2D tmpNodePoints[MAX_NODE_POINTS];
-	CNodeAddress t_ResultNodes[MAX_NODE_POINTS];
-	RwIm2DVertex t_LineVerts[MAX_NODE_POINTS * 4];
-	CNodeAddress m_ResultNodes[MAX_NODE_POINTS];
-	RwIm2DVertex m_LineVerts[MAX_NODE_POINTS * 4];
+        CVector2D shift[2];
+        std::array<char, 1024> pathNodesToStream{};
+        std::array<int, 50000> pathNodes{};
+        std::array<CVector2D, MAX_NODE_POINTS> tmpNodePoints{};
+        std::array<CNodeAddress, MAX_NODE_POINTS> t_ResultNodes{};
+        std::array<RwIm2DVertex, MAX_NODE_POINTS * 4> t_LineVerts{};
+        std::array<CNodeAddress, MAX_NODE_POINTS> m_ResultNodes{};
+        std::array<RwIm2DVertex, MAX_NODE_POINTS * 4> m_LineVerts{};
 
 public:
 	inline GPS()

--- a/src/util/DistCache.cpp
+++ b/src/util/DistCache.cpp
@@ -2,43 +2,47 @@
 
 namespace util
 {
+    DistCache::DistCache()
+    {
+        cache.reserve(MAX_ITEMS);
+        cache2D.reserve(MAX_ITEMS);
+    }
+
     float DistCache::GetDist(const CVector &v1, const CVector &v2)
     {
         const CVectorPair the_pair = {v1, v2};
-        if (cache.find(the_pair) != cache.end())
+        auto it = cache.find(the_pair);
+        if (it != cache.end())
         {
-            return cache[the_pair];
+            return it->second;
         }
-        else
-        {
-            while (cache.size() >= MAX_ITEMS)
-            {
-                cache.clear();
-            }
 
-            float out = DistanceBetweenPoints(v1, v2);
-            cache[the_pair] = out;
-            return out;
+        if (cache.size() >= MAX_ITEMS)
+        {
+            cache.clear();
         }
+
+        float out = DistanceBetweenPoints(v1, v2);
+        cache.emplace(the_pair, out);
+        return out;
     }
 
     float DistCache::GetDist2D(const CVector2D &v1, const CVector2D &v2)
     {
         const CVector2DPair the_pair = {v1, v2};
-        if (cache2D.find(the_pair) != cache2D.end())
+        auto it = cache2D.find(the_pair);
+        if (it != cache2D.end())
         {
-            return cache2D[the_pair];
+            return it->second;
         }
-        else
-        {
-            while (cache2D.size() >= MAX_ITEMS)
-            {
-                cache2D.clear();
-            }
 
-            float out = DistanceBetweenPoints(v1, v2);
-            cache2D[the_pair] = out;
-            return out;
+        if (cache2D.size() >= MAX_ITEMS)
+        {
+            cache2D.clear();
         }
+
+        float out = DistanceBetweenPoints(v1, v2);
+        cache2D.emplace(the_pair, out);
+        return out;
     }
 }

--- a/src/util/DistCache.h
+++ b/src/util/DistCache.h
@@ -32,8 +32,8 @@ struct CVector2DPair
 
 	bool operator<(const CVector2DPair &a_pair) const noexcept
 	{
-		CVector2D sum1 = CVector2D(v1.x + v2.x, v1.y + v1.y);
-		CVector2D sum2 = CVector2D(a_pair.v1.x + a_pair.v2.x, a_pair.v2.y + a_pair.v2.y);
+                CVector2D sum1 = CVector2D(v1.x + v2.x, v1.y + v2.y);
+                CVector2D sum2 = CVector2D(a_pair.v1.x + a_pair.v2.x, a_pair.v1.y + a_pair.v2.y);
 
 		return sum1.Magnitude() < sum2.Magnitude();
 	};
@@ -74,15 +74,17 @@ namespace std
 
 namespace util
 {
-	class DistCache
-	{
-	private:
-		std::unordered_map<CVectorPair, float> cache{};
-		std::unordered_map<CVector2DPair, float> cache2D{};
+        class DistCache
+        {
+        private:
+                std::unordered_map<CVectorPair, float> cache{};
+                std::unordered_map<CVector2DPair, float> cache2D{};
 
-	public:
-		float GetDist(const CVector &v1, const CVector &v2);
-		float GetDist2D(const CVector2D &v1, const CVector2D &v2);
+        public:
+                DistCache();
+
+                float GetDist(const CVector &v1, const CVector &v2);
+                float GetDist2D(const CVector2D &v1, const CVector2D &v2);
 
 		/*
 		inline float GetDist2D(const CVector &v1, const CVector &v2)


### PR DESCRIPTION
## Summary
- replace manual initialization loops with `std::fill`
- use `std::array` containers for fixed-size buffers
- add capacity reservation and lookups to `DistCache`
- fix typo in `CVector2DPair` comparison helpers

## Testing
- `numake build build_mingw` *(fails: Invalid structure size of CPathFind, CVehicle, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68520015fc94832186713fe60e9aacbf